### PR TITLE
Added test Repository and ViewModel with Hilt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
 }
 // Allow references to generated code
 kapt {

--- a/app/src/main/java/com/example/weatherbuddy/MainActivity.kt
+++ b/app/src/main/java/com/example/weatherbuddy/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.weatherbuddy.ui.splashScreen.SplashScreen
 import com.example.weatherbuddy.ui.theme.WeatherBuddyTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -21,7 +22,8 @@ class MainActivity : ComponentActivity() {
             WeatherBuddyTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    Greeting("Android")
+//                    Greeting("Android")
+                    SplashScreen()
                 }
             }
         }

--- a/app/src/main/java/com/example/weatherbuddy/repositories/WeatherRepository.kt
+++ b/app/src/main/java/com/example/weatherbuddy/repositories/WeatherRepository.kt
@@ -1,0 +1,10 @@
+package com.example.weatherbuddy.repositories
+
+import javax.inject.Inject
+
+class WeatherRepository @Inject constructor(){
+    fun test():String
+    {
+        return "Test Success"
+    }
+}

--- a/app/src/main/java/com/example/weatherbuddy/ui/splashScreen/SplashScreen.kt
+++ b/app/src/main/java/com/example/weatherbuddy/ui/splashScreen/SplashScreen.kt
@@ -1,0 +1,25 @@
+package com.example.weatherbuddy.ui.splashScreen
+
+import android.window.SplashScreen
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.weatherbuddy.viewModels.SplashViewModel
+
+@Composable
+fun SplashScreen()
+{
+    val splashViewModel:SplashViewModel= hiltViewModel()
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text(text = splashViewModel.test())
+    }
+}

--- a/app/src/main/java/com/example/weatherbuddy/viewModels/SplashViewModel.kt
+++ b/app/src/main/java/com/example/weatherbuddy/viewModels/SplashViewModel.kt
@@ -1,0 +1,16 @@
+package com.example.weatherbuddy.viewModels
+
+import androidx.lifecycle.ViewModel
+import com.example.weatherbuddy.repositories.WeatherRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val weatherRepository: WeatherRepository
+) :ViewModel(){
+    fun test():String
+    {
+       return weatherRepository.test()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ activityCompose = "1.8.2"
 composeBom = "2024.02.02"
 coreKtx = "1.12.0"
 espressoCore = "3.5.1"
+hiltNavigationCompose = "1.2.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 lifecycleRuntimeKtx = "2.7.0"
@@ -16,6 +17,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-compose-ui = {group="androidx.compose.ui", name="ui"}


### PR DESCRIPTION
### Test Repository & ViewModel with Hilt

Used [Android Hilt Documentation](https://developer.android.com/jetpack/compose/libraries#kts) to learn how to add Hilt View Models and Inject them.

Needs to add new libarary:
`implementation("androidx.hilt:hilt-navigation-compose:1.0.0")`
 It allows to use Hilt View Models in App.