### PR TITLE
Added ViewModel Lifecycle Library for scope

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,9 @@ dependencies {
 
     implementation (libs.androidx.constraintlayout.compose)
 
+    implementation( libs.androidx.lifecycle.viewmodel.ktx)
+
+
 
 }
 // Allow references to generated code

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ androidx-compose-ui-tooling = {group="androidx.compose.ui", name="ui-tooling"}
 androidx-compose-material3= {group="androidx.compose.material3", name="material3"}
 androidx-compose-ui-test-junit4= {group="androidx.compose.ui", name="ui-test-junit4"}
 androidx-compose-ui-test-manifest= {group="androidx.compose.ui", name="ui-test-manifest"}
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleRuntimeKtx" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltDependency" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltDependency" }
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
### ViewModel Lifecycle Library

Added Libarary because ViewModel Lifecycle was needed for realtime search but not required yet.