### PR TITLE
SCRUM-5 - City state is null

### DIFF
--- a/app/src/main/java/com/example/weatherbuddy/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/com/example/weatherbuddy/ui/mainScreen/MainScreen.kt
@@ -181,7 +181,7 @@ fun SearchBar(
             LazyColumn {
                 items(citiesList.value) { city ->
                     Text(
-                        text = "${city.name},${city.state},${city.country}",
+                        text = "${city.name}${city.state?.let {",${city.state}"}?:""},${city.country}",
                         fontSize = 18.sp,
                         modifier = Modifier
                             .fillMaxWidth()


### PR DESCRIPTION
Some Cities states are not available in OpenWeather API. So, while showing details in search it gives 'null' written in place of state name for those cities.

Before, I was directly converting `city.state` to text.

Now, I added conditional null check. As, shown below:
`${city.state?.let {",${city.state}"}?:""}`

Issue #25  is resolved